### PR TITLE
Different check for changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             - v1-
           name: Restoring cache
       - run:
-          command: nix-shell --run 'shake --digest-and-input build'
+          command: nix-shell --run 'shake --digest-and build'
           name: Build
       - run:
           command: nix-shell --run 'shake test'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             - v1-
           name: Restoring cache
       - run:
-          command: nix-shell --run 'shake build'
+          command: nix-shell --run 'shake --digest-and-input build'
           name: Build
       - run:
           command: nix-shell --run 'shake test'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             - v1-
           name: Restoring cache
       - run:
-          command: nix-shell --run 'shake --digest-and build'
+          command: nix-shell --run 'shake build'
           name: Build
       - run:
           command: nix-shell --run 'shake test'

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -9,10 +9,11 @@ import "base" Control.Monad.IO.Class        (liftIO)
 import "base" Data.Foldable                 (for_)
 import "text" Data.Text                     (pack, unpack)
 import "shake" Development.Shake
-    ( CmdOption(Cwd, EchoStdout, FileStdout, Traced)
+    ( Change(ChangeModtimeAndDigest)
+    , CmdOption(Cwd, EchoStdout, FileStdout, Traced)
     , Exit(Exit)
     , Rules
-    , ShakeOptions(shakeFiles, shakeThreads, shakeVersion)
+    , ShakeOptions(shakeChange, shakeFiles, shakeThreads, shakeVersion)
     , Stdout(Stdout)
     , cmd
     , cmd_
@@ -80,9 +81,12 @@ main = do
   packages' <- getDirectoryFilesIO "" ["packages/*/shake.dhall"]
   packages <- traverse (detailed . input auto . pack . ("./" <>)) packages'
   shakeVersion <- getHashedShakeVersion ["Shakefile.hs"]
-  let options = shakeOptions { shakeFiles, shakeThreads, shakeVersion }
-      shakeFiles = buildDir
-      shakeThreads = 0
+  let options = shakeOptions
+        { shakeChange = ChangeModtimeAndDigest
+        , shakeFiles = buildDir
+        , shakeThreads = 0
+        , shakeVersion
+        }
   shakeArgs options $ do
     want ["build"]
 


### PR DESCRIPTION
Should cut down CI time considerably by doing something less naive than timestamp checks.